### PR TITLE
Pretix running but with css issues

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,18 +1,27 @@
 version: '3'
 services:
-  pre-install-config:
-    # Handle install-time config
-    image: alpine
-    container_name: pre-config
-    entrypoint: wget https://raw.githubusercontent.com/gvarela1981/pretix-docker-compose/master/etc/pretix.cfg -O cfg/pretix.cfg
-    volumes: 
-      - cfg
+  database:
+    image: postgres:9.6-alpine
+    container_name: database
+    ports:
+      - "5432:5432"
+    environment: 
+      - POSTGRES_USER=pretix
+      - POSTGRES_PASSWORD=pretix
+      - POSTGRES_DB=pretix
+      - POSTGRES_HOST_AUTH_METHOD=md5
+    volumes:
+      - postgres:/var/lib/postgresql/data 
+    networks:
+      - backend
 
   redis:
     image: redis:latest
     container_name: cache
     ports:
       - "6379:6379"
+    volumes:
+      - ./etc/redis.conf:/usr/local/etc/redis/redis.conf
     networks:
       - backend
 
@@ -25,29 +34,30 @@ services:
     ports:
       - "8000:80"
     volumes:
-      - cfg:/etc/pretix/
+      - ./etc/pretix.cfg:/etc/pretix/pretix.cfg
       - data:/data
-      - src:/pretix/src
     networks:
       - backend
-  database:
-    image: postgres:9.6
-    container_name: database
-    #entrypoint: psql -U postgres postgres
-    ports:
-      - "5432:5432"
-    environment: 
-      - POSTGRES_USER=pretix
-      - POSTGRES_PASSWORD=postgres
-    volumes:
-      - pg_data:/var/lib/postgresql/data 
-    networks:
-      - backend
+
 volumes:
   data:
-  pg_data:
-  cfg:
+    driver: local
+    driver_opts:
+      type: 'none'
+      o: 'bind'
+      device: ${PWD}/rootfs/data
+  postgres:
+    driver: local
+    driver_opts:
+      type: 'none'
+      o: 'bind'
+      device: ${PWD}/rootfs/postgres
   src:
+    driver: local
+    driver_opts:
+      type: 'none'
+      o: 'bind'
+      device: ${PWD}/rootfs/src
 
 networks:
   backend:

--- a/etc/pretix.cfg
+++ b/etc/pretix.cfg
@@ -1,39 +1,40 @@
 [pretix]
-instance_name=My pretix installation
-url=http://192.168.0.9
+instance_name=foss4g
+url=https://localhost
 currency=EUR
-; DO NOT change the following value, it has to be set to the location of the
-; directory *inside* the docker container
 datadir=/data
 trust_x_forwarded_for=on
 trust_x_forwarded_proto=on
 
-[database]
-; Replace postgresql with mysql for MySQL
-backend=postgresql
-name=pretix
-user=pretix
-; Replace with the password you chose above
-password=postgres
-; In most docker setups, 172.17.0.1 is the address of the docker host. Adjuts
-; this to wherever your database is running, e.g. the name of a linked container
-; or of a mounted MySQL socket.
-host=192.168.0.9
+; [mail]
+; from=
+; host=
+; user=
+; password=
+; port=2525
+; tls=True
 
 [mail]
 ; See config file documentation for more options
 from=tickets@yourdomain.com
 ; This is the default IP address of your docker host in docker's virtual
 ; network. Make sure postfix listens on this address.
-host=192.168.0.9
+host=172.17.0.1
+
+[django]
+debug=true
+
+[database]
+backend=postgresql
+name=pretix
+user=pretix
+password=pretix
+host=database
 
 [redis]
-location=unix:///var/run/redis/redis.sock?db=0
-; Remove the following line if you are unsure about your redis' security
-; to reduce impact if redis gets compromised.
+location=redis://redis/0
 sessions=true
 
 [celery]
-backend=redis+socket:///var/run/redis/redis.sock?virtual_host=1
-broker=redis+socket:///var/run/redis/redis.sock?virtual_host=2
-
+backend=redis://redis/1
+broker=redis://redis/2

--- a/etc/redis.conf
+++ b/etc/redis.conf
@@ -1,0 +1,34 @@
+requirepass some-long-password
+appendonly yes
+
+################################## NETWORK #####################################
+
+# By default, if no "bind" configuration directive is specified, Redis listens
+# for connections from all the network interfaces available on the server.
+# It is possible to listen to just one or multiple selected interfaces using
+# the "bind" configuration directive, followed by one or more IP addresses.
+#
+# Examples:
+#
+# bind 192.168.1.100 10.0.0.1
+# bind 127.0.0.1 ::1
+#
+# ~~~ WARNING ~~~ If the computer running Redis is directly exposed to the
+# internet, binding to all the interfaces is dangerous and will expose the
+# instance to everybody on the internet. So by default we uncomment the
+# following bind directive, that will force Redis to listen only into
+# the IPv4 loopback interface address (this means Redis will be able to
+# accept connections only from clients running into the same computer it
+# is running).
+#
+# IF YOU ARE SURE YOU WANT YOUR INSTANCE TO LISTEN TO ALL THE INTERFACES
+# JUST COMMENT THE FOLLOWING LINE.*
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+bind 127.0.0.1
+
+ // and all configurations that can be specified
+ // what you put here overwrites the default settings that have the
+ container
+ 
+unixsocket /var/run/redis/redis.sock
+unixsocketperm 777


### PR DESCRIPTION
He seguido las instrucciones en https://docs.pretix.eu/en/latest/admin/installation/docker_smallscale.html paso a paso convirtiéndolas en el docker-compose. La configuración de redis no me queda clara todavía. No he comprobado el https.

He quitado el plugin que viene por defecto en la carpeta rootfs, me estaba dando errores de dependencias que faltaban a la hora de lanzar pretix. Esto queda también pendiente de revisar.

Para ejecutar Pretix hay que ejecutar `docker-compose up` en la carpeta base del repositorio.

Se quedará como congelado después de imprimir:

```
database    | LOG:  database system is ready to accept connections
cache       | 1:M 20 Jun 2020 10:34:51.895 * Ready to accept connections
database    | LOG:  autovacuum launcher started
pretix      | DEBUG 2020-06-20 10:34:53,223 asyncio selector_events Using selector: EpollSelector
```

Esperar varios minutos. A mi me tardó unos 6 minutos en continuar:

```
pretix      | Operations to perform:
pretix      |   Apply all migrations: auth, badges, banktransfer, contenttypes, oauth2_provider, otp_static, otp_totp, paypal, pretixapi, pretixbase, pretixdroid, pretixhelpers, pretixmultidomain, sessions, stripe, ticketoutputpdf
pretix      | Running migrations:
pretix      |   Applying banktransfer.0002_auto_20160908_2020... OK
pretix      |   Applying banktransfer.0003_banktransaction_comment... OK
pretix      |   Applying banktransfer.0004_auto_20170619_1125... OK
```

Luego estará pretix disponible en `http://localhost:8000/control/login?next=/control/`

Se puede loguear con el usuario `admin@localhost` y la contraseña `admin`.

Después del login a mi me sale un error de compresión del css:
![imagen](https://user-images.githubusercontent.com/726590/85200194-9719bf00-b2f5-11ea-9972-f39c13335fc7.png)

Entré en el contenedor con `docker exec -it pretix /bin/bash`
Encontré el fichero `manage.py` en `/pretix/src`. Pero ejecutando lo que sugiere el error, no se arregla. Parece que hay un error de Django:

`DEBUG 2020-06-20 10:45:08,649 asyncio selector_events Using selector: EpollSelector
Compressing... Invalid template /usr/local/lib/python3.6/site-packages/django_otp/templates/otp/admin19/login.html: 'admin_static' is not a registered tag library. Must be one of:
`

Recomiendo limpiar los contenedores en cada reinicio (`docker-compose rm`) para asegurarnos que no tocamos nada que no acabe en el docker-compose. 